### PR TITLE
Re-enable opam file generation, add template file for pin-depends

### DIFF
--- a/current-web-pipelines.opam
+++ b/current-web-pipelines.opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/tarides/current-web-pipelines/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.10"}
-  "current"
-  "current_web"
-  "current_git"
+  "current" {>= "0.5"}
+  "current_web" {>= "0.5"}
+  "current_git" {>= "0.5"}
   "fmt"
   "routes" {>= "2.0.0"}
   "odoc" {with-doc}

--- a/current-web-pipelines.opam.template
+++ b/current-web-pipelines.opam.template
@@ -1,0 +1,5 @@
+pin-depends: [
+  ["current.dev" "git+https://github.com/ocurrent/ocurrent.git#5661fe2848c586efa3c7d82c39fa0d0a7a5e5c53"]
+  ["current_web.dev" "git+https://github.com/ocurrent/ocurrent.git#5661fe2848c586efa3c7d82c39fa0d0a7a5e5c53"]
+  ["current_git.dev" "git+https://github.com/ocurrent/ocurrent.git#5661fe2848c586efa3c7d82c39fa0d0a7a5e5c53"]
+]

--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,7 @@
 
 (name current-web-pipelines)
 
-(generate_opam_files false)
+(generate_opam_files true)
 
 (source
  (github tarides/current-web-pipelines))
@@ -26,4 +26,4 @@
    (>= 0.5))
   fmt
   (routes
-   (>= 2.0))))
+   (>= 2.0.0))))


### PR DESCRIPTION
Corrects the disabling of opam file generation from dune-project, which was done in #7.